### PR TITLE
apt-get install buildessential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/miniconda3
 
+RUN apt-get update -y && apt-get install build-essential -y
+
 COPY generate.sh .
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Add this so I don't have to put `gcc` or `cython` in all my `env.yaml`s.

Eventually make this a separate list of things to `apt-get install` that you can pass in?